### PR TITLE
Fix output crash when the LR file is located outside of the HECIL dir

### DIFF
--- a/Create_Corrected_AllLRReads.py
+++ b/Create_Corrected_AllLRReads.py
@@ -11,7 +11,7 @@ num_LRread=int(sys.argv[2])
 corrref_file=sys.argv[3]
 num_corrLRread=int(sys.argv[4])
 
-out='Corrected_'+ref_file
+out=ref_file+".corrected"
 fout=open(out,'w')
 fref=open(ref_file,'r')
 


### PR DESCRIPTION
Hi,

I found out that if the file containing the long reads to correct is not located in the HECIL directory, it causes the program to crash at the very end, when outputting the corrected long reads.

Here's what it looks like from the terminal:

```
python HECIL.py --LR /mnt/nfs/NGSData/longReads/ADP1/MWE.fasta --SR /mnt/nfs/NGSData/shortReads/NaS/ADP1/ADP1.fasta --length 250 --output corADP1.fasta
Started running alignment
[samopen] SAM header is present: 1 sequences.
-e Finished running alignment

[...]

-e Finished running correction

-e Generating output file with all (corrected and uncorrected) reads

Traceback (most recent call last):
  File "Create_Corrected_AllLRReads.py", line 15, in <module>
    fout=open(out,'w')
IOError: [Errno 2] No such file or directory: 'Corrected_/mnt/nfs/NGSData/longReads/ADP1/MWE.fasta'
-e Finished running HECIL
```

Adding a "Corrected_" prefix indeed is a bad idea when the LR file is provided from another directory. Adding a suffix instead, like so, solves the problem.

Best,
Pierre